### PR TITLE
Customize the Element theme with configurable colors

### DIFF
--- a/.changeset/empty-seas-search.md
+++ b/.changeset/empty-seas-search.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/element-web-opendesk-module': patch
+---
+
+Customize the Element theme with configurable colors.

--- a/.changeset/tender-papayas-poke.md
+++ b/.changeset/tender-papayas-poke.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/element-web-opendesk-module': patch
+---
+
+Add support for future Element versions.

--- a/e2e/src/deploy/elementWeb/config.json
+++ b/e2e/src/deploy/elementWeb/config.json
@@ -54,7 +54,10 @@
       "ics_navigation_json_url": "https://example.com/navigation.json",
       "ics_silent_url": "https://example.com/silent",
       "portal_logo_svg_url": "https://example.com/logo.svg",
-      "portal_url": "https://example.com"
+      "portal_url": "https://example.com",
+      "custom_css_variables": {
+        "--cpd-color-text-action-accent": "purple"
+      }
     }
   },
   "net.nordeck.element_web.module.widget_lifecycle": {

--- a/e2e/src/opendesk.spec.ts
+++ b/e2e/src/opendesk.spec.ts
@@ -18,11 +18,20 @@ import { expect } from '@playwright/test';
 import { test } from './fixtures';
 import { getElementWebUrl } from './util';
 
-test.describe('Navbar Module', () => {
+test.describe('OpenDesk Module', () => {
   test('renders the link to the portal', async ({ page }) => {
     await page.goto(getElementWebUrl());
     const navigation = page.getByRole('navigation');
     const link = navigation.getByRole('link', { name: 'Show portal' });
     await expect(link).toHaveAttribute('href', 'https://example.com');
+  });
+
+  test('uses a custom primary color from the configuration', async ({
+    alicePage,
+    aliceElementWebPage,
+  }) => {
+    await expect(
+      alicePage.getByRole('button', { name: 'Send a Direct Message' }),
+    ).toHaveCSS('background-color', 'rgb(128, 0, 128)'); // -> purple
   });
 });

--- a/packages/element-web-opendesk-module/README.md
+++ b/packages/element-web-opendesk-module/README.md
@@ -6,6 +6,11 @@ It uses the [Module API](https://www.npmjs.com/package/@matrix-org/react-sdk-mod
 
 <img src="./docs/navbar.png" alt="openDesk navbar" />
 
+Features:
+
+- Add a navigation bar to Element.
+- Customize the theme colors of Element.
+
 ## Requirements
 
 The minimal Element version to use this module is `1.11.41`.
@@ -32,6 +37,10 @@ The module provides required configuration options:
 - `portal_logo_svg_url` - The URL of the portal `logo.svg` file.
 - `portal_url` - The URL of the portal.
 
+There are also other optional configuration options:
+
+- `custom_css_variables` - a configuration of `--cpd-color-*` css variables to override selected colors in the Element theme. The [Element Compound](https://compound.element.io/?path=/docs/tokens-semantic-colors--docs) documentation has a list of all available options.
+
 Example configuration:
 
 ```json
@@ -41,7 +50,12 @@ Example configuration:
       "ics_navigation_json_url": "https://example.com/navigation.json",
       "ics_silent_url": "https://example.com/silent",
       "portal_logo_svg_url": "https://example.com/logo.svg",
-      "portal_url": "https://example.com"
+      "portal_url": "https://example.com",
+
+      // ... add more optional configurations
+      "custom_css_variables": {
+        "--cpd-color-text-action-accent": "purple"
+      }
     }
   }
 }

--- a/packages/element-web-opendesk-module/jest.config.js
+++ b/packages/element-web-opendesk-module/jest.config.js
@@ -22,4 +22,8 @@ module.exports = {
   preset: 'ts-jest',
   testEnvironment: 'jsdom',
   setupFilesAfterEnv: ['<rootDir>/src/setupTests.ts'],
+  // TODO: jest doesn't support prettier 3.0 for inline snapshots in Jest <30.
+  // Remove this line when it is released and updated.
+  // See https://github.com/jestjs/jest/issues/14305
+  prettierPath: null,
 };

--- a/packages/element-web-opendesk-module/src/OpenDeskModule.test.tsx
+++ b/packages/element-web-opendesk-module/src/OpenDeskModule.test.tsx
@@ -22,6 +22,9 @@ import {
 import { render, screen } from '@testing-library/react';
 import { Fragment } from 'react';
 import { OpenDeskModule } from './OpenDeskModule';
+import { applyStyles } from './utils/applyStyles';
+
+jest.mock('./utils/applyStyles');
 
 describe('OpenDeskModule', () => {
   let moduleApi: jest.Mocked<ModuleApi>;
@@ -41,6 +44,7 @@ describe('OpenDeskModule', () => {
 
   it('should register custom translations', () => {
     new OpenDeskModule(moduleApi);
+
     expect(moduleApi.registerTranslations).toBeCalledWith({
       'Portal logo': {
         en: 'Portal logo',
@@ -54,6 +58,22 @@ describe('OpenDeskModule', () => {
         en: 'Show portal',
         de: expect.any(String),
       },
+    });
+  });
+
+  it('should apply custom styles if configured', () => {
+    moduleApi.getConfigValue.mockReturnValue({
+      ics_navigation_json_url: 'https://example.com/navigation.json',
+      ics_silent_url: 'https://example.com/silent',
+      portal_logo_svg_url: 'https://example.com/logo.svg',
+      portal_url: 'https://example.com',
+      custom_css_variables: { '--cpd-color-text-action-accent': 'purple' },
+    });
+
+    new OpenDeskModule(moduleApi);
+
+    expect(applyStyles).toBeCalledWith({
+      '--cpd-color-text-action-accent': 'purple',
     });
   });
 

--- a/packages/element-web-opendesk-module/src/OpenDeskModule.tsx
+++ b/packages/element-web-opendesk-module/src/OpenDeskModule.tsx
@@ -83,7 +83,9 @@ export class OpenDeskModule extends RuntimeModule {
         // Add the ref to our only children -> the MatrixChat component
         const children =
           React.Children.only(this.props.children) &&
-          React.isValidElement<{ ref: unknown }>(this.props.children)
+          React.isValidElement<{ ref: unknown }>(this.props.children) &&
+          'ref' in this.props.children &&
+          !this.props.children.ref
             ? React.cloneElement(this.props.children, { ref: this.ref })
             : this.props.children;
 

--- a/packages/element-web-opendesk-module/src/OpenDeskModule.tsx
+++ b/packages/element-web-opendesk-module/src/OpenDeskModule.tsx
@@ -32,6 +32,7 @@ import {
   assertValidOpenDeskModuleConfig,
 } from './config';
 import { theme } from './theme';
+import { applyStyles } from './utils/applyStyles';
 
 export class OpenDeskModule extends RuntimeModule {
   private readonly config: OpenDeskModuleConfig;
@@ -63,6 +64,10 @@ export class OpenDeskModule extends RuntimeModule {
     assertValidOpenDeskModuleConfig(config);
 
     this.config = config;
+
+    if (config.custom_css_variables) {
+      applyStyles(config.custom_css_variables);
+    }
 
     // TODO: This should be a functional component. Element calls `ReactDOM.render` and uses the
     // return value as a reference to the MatrixChat component. Then they call a function on this

--- a/packages/element-web-opendesk-module/src/config.test.ts
+++ b/packages/element-web-opendesk-module/src/config.test.ts
@@ -32,6 +32,16 @@ describe('assertValidOpenDeskModuleConfig', () => {
     expect(() => assertValidOpenDeskModuleConfig(config)).not.toThrow();
   });
 
+  it('should accept optional properties', () => {
+    expect(() =>
+      assertValidOpenDeskModuleConfig({
+        ...config,
+        custom_css_variables: { '--cpd-color-text-action-accent': 'purple' },
+        additional: 'foo',
+      }),
+    ).not.toThrow();
+  });
+
   it('should accept additional properties', () => {
     expect(() =>
       assertValidOpenDeskModuleConfig({ ...config, additional: 'foo' }),
@@ -55,9 +65,15 @@ describe('assertValidOpenDeskModuleConfig', () => {
     { portal_url: null },
     { portal_url: 123 },
     { portal_url: 'no-uri' },
+    { custom_css_variables: { '--other-name': 'purple' } },
+    { custom_css_variables: { '--cpd-color-blub': null } },
+    { custom_css_variables: { '--cpd-color-blub': 123 } },
+    { custom_css_variables: { '--cpd-color-blub': '' } },
   ])('should reject wrong configuration permissions %j', (patch) => {
     expect(() =>
       assertValidOpenDeskModuleConfig({ ...config, ...patch }),
-    ).toThrow(/is required|must be a string|must be a valid uri/);
+    ).toThrow(
+      /is required|must be a string|must be a valid uri|to be empty|is not allowed/,
+    );
   });
 });

--- a/packages/element-web-opendesk-module/src/config.test.ts
+++ b/packages/element-web-opendesk-module/src/config.test.ts
@@ -37,7 +37,6 @@ describe('assertValidOpenDeskModuleConfig', () => {
       assertValidOpenDeskModuleConfig({
         ...config,
         custom_css_variables: { '--cpd-color-text-action-accent': 'purple' },
-        additional: 'foo',
       }),
     ).not.toThrow();
   });

--- a/packages/element-web-opendesk-module/src/config.ts
+++ b/packages/element-web-opendesk-module/src/config.ts
@@ -45,6 +45,14 @@ export interface OpenDeskModuleConfig {
    * @example `https://example.com`
    */
   portal_url: string;
+
+  /**
+   * Set custom values to compound color css variables in the theme.
+   * Reference: https://compound.element.io/?path=/docs/tokens-semantic-colors--docs
+   *
+   * @example `{ "--cpd-color-text-action-accent": "purple" }`
+   */
+  custom_css_variables?: { [key: string]: string };
 }
 
 const openDeskModuleConfigSchema = Joi.object<OpenDeskModuleConfig, true>({
@@ -52,6 +60,12 @@ const openDeskModuleConfigSchema = Joi.object<OpenDeskModuleConfig, true>({
   ics_silent_url: Joi.string().uri().required(),
   portal_logo_svg_url: Joi.string().uri().required(),
   portal_url: Joi.string().uri().required(),
+  custom_css_variables: Joi.object().pattern(
+    Joi.string()
+      .pattern(/^--cpd-color-/)
+      .required(),
+    Joi.string(),
+  ),
 })
   .unknown()
   .required();

--- a/packages/element-web-opendesk-module/src/utils/applyStyles.test.tsx
+++ b/packages/element-web-opendesk-module/src/utils/applyStyles.test.tsx
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { applyStyles } from './applyStyles';
+
+describe('applyStyles', () => {
+  beforeEach(() => {
+    document.head.innerHTML = '';
+  });
+
+  it('should apply the styles to the head', () => {
+    applyStyles({
+      '--cpd-color-text-action-accent': 'green',
+      '--cpd-color-text-critical-primary': 'red',
+    });
+
+    expect(document.getElementsByTagName('style').item(0)?.outerHTML)
+      .toMatchInlineSnapshot(`
+"<style type="text/css">
+      .cpd-theme-light.cpd-theme-light.cpd-theme-light.cpd-theme-light,
+      .cpd-theme-dark.cpd-theme-dark.cpd-theme-dark.cpd-theme-dark,
+      .cpd-theme-light-hc.cpd-theme-light-hc.cpd-theme-light-hc.cpd-theme-light-hc,
+      .cpd-theme-dark-hc.cpd-theme-dark-hc.cpd-theme-dark-hc.cpd-theme-dark-hc {
+        --cpd-color-text-action-accent: green; --cpd-color-text-critical-primary: red
+      }
+    </style>"
+`);
+  });
+});

--- a/packages/element-web-opendesk-module/src/utils/applyStyles.ts
+++ b/packages/element-web-opendesk-module/src/utils/applyStyles.ts
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2023 Nordeck IT + Consulting GmbH
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Append extra styles to the `<head>` of Element. This should only be used for
+ * setting compound css variables (ex: `--cpd-color-*`).
+ *
+ * @param cssVariableColors - a map of css variables (example: `{"--cpd-color-text-action-accent": "red"}`)
+ */
+export function applyStyles(cssVariableColors: Record<string, string>) {
+  const colorsString = Object.entries(cssVariableColors)
+    .map(([variable, value]) => `${variable}: ${value}`)
+    .join('; ');
+
+  const styles = document.createElement('style');
+  styles.setAttribute('type', 'text/css');
+  styles.innerHTML = `
+      .cpd-theme-light.cpd-theme-light.cpd-theme-light.cpd-theme-light,
+      .cpd-theme-dark.cpd-theme-dark.cpd-theme-dark.cpd-theme-dark,
+      .cpd-theme-light-hc.cpd-theme-light-hc.cpd-theme-light-hc.cpd-theme-light-hc,
+      .cpd-theme-dark-hc.cpd-theme-dark-hc.cpd-theme-dark-hc.cpd-theme-dark-hc {
+        ${colorsString}
+      }
+    `;
+  document.head.appendChild(styles);
+}


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

The module will inject custom CSS into the page that will exchange selected colors in the Element theme. This can be used until this is natively supported in Element with the flexibility that we need.

This also makes the module compatible with the upcoming Element releases that include https://github.com/vector-im/element-web/pull/26395.

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [x] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [x] Added or updated documentation.
- [x] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
