### PR TITLE
Add configurable color option to expanded launcher icon

### DIFF
--- a/.changeset/small-beans-fry.md
+++ b/.changeset/small-beans-fry.md
@@ -1,0 +1,5 @@
+---
+'@nordeck/element-web-opendesk-module': minor
+---
+
+Launcher icon color when expanded is now configurable

--- a/packages/element-web-opendesk-module/README.md
+++ b/packages/element-web-opendesk-module/README.md
@@ -39,6 +39,12 @@ The module provides the following optional configuration options:
   - `portal_url` - The URL of the portal.
 - `custom_css_variables` - a configuration of `--cpd-color-*` css variables to override selected colors in the Element theme. The [Element Compound](https://compound.element.io/?path=/docs/tokens-semantic-colors--docs) documentation has a list of all available options.
 
+For the navigation bar and launcher, the following variables are relevant:
+
+- `--cpd-color-text-action-accent` sets the background of the launcher icon when expanded and the top border of the menu
+- `--cpd-color-icon-on-solid-primary` sets the color of the launcher icon when expanded
+- `
+
 Example configuration:
 
 ```json
@@ -54,7 +60,8 @@ Example configuration:
 
       // ... add more optional configurations
       "custom_css_variables": {
-        "--cpd-color-text-action-accent": "purple"
+        "--cpd-color-text-action-accent": "#dadada",
+        "--cpd-color-icon-on-solid-primary": "#aa0000"
       }
     }
   }

--- a/packages/element-web-opendesk-module/src/components/Navbar/Launcher.tsx
+++ b/packages/element-web-opendesk-module/src/components/Navbar/Launcher.tsx
@@ -28,7 +28,9 @@ const Root = styled.button`
     ariaExpanded ? theme.compound.color.textActionAccent : 'transparent'};
   border: none;
   color: ${({ 'aria-expanded': ariaExpanded, theme }) =>
-    ariaExpanded ? theme.navbar.color : theme.compound.color.textPrimary};
+    ariaExpanded
+      ? theme.compound.color.iconOnSolidPrimary
+      : theme.compound.color.textPrimary};
   cursor: pointer;
   display: flex;
   padding: 0 22px;

--- a/packages/element-web-opendesk-module/src/global.d.ts
+++ b/packages/element-web-opendesk-module/src/global.d.ts
@@ -23,6 +23,7 @@ declare module 'styled-components' {
         bgCanvasDefault: string;
         textActionAccent: string;
         textPrimary: string;
+        iconOnSolidPrimary: string;
       };
       font: {
         bodyMdSemibold: string;
@@ -31,7 +32,6 @@ declare module 'styled-components' {
     navbar: {
       border: string;
       boxShadow: string;
-      color: string;
       height: string;
       hoverBackgroundColor: string;
       offsetHeight: string;

--- a/packages/element-web-opendesk-module/src/theme.ts
+++ b/packages/element-web-opendesk-module/src/theme.ts
@@ -19,6 +19,7 @@ import { DefaultTheme } from 'styled-components';
 const bgCanvasDefault = 'var(--cpd-color-bg-canvas-default)';
 const textActionAccent = 'var(--cpd-color-text-action-accent)';
 const textPrimary = 'var(--cpd-color-text-primary)';
+const iconOnSolidPrimary = 'var(--cpd-color-icon-on-solid-primary)';
 
 const bodyMdSemibold = 'var(--cpd-font-body-md-semibold)';
 
@@ -28,6 +29,7 @@ const theme: DefaultTheme = {
       bgCanvasDefault,
       textActionAccent,
       textPrimary,
+      iconOnSolidPrimary,
     },
     font: {
       bodyMdSemibold,
@@ -36,7 +38,6 @@ const theme: DefaultTheme = {
   navbar: {
     border: '1px solid rgba(27, 29, 34, 0.1)',
     boxShadow: '4px 4px 12px 0 rgba(118, 131, 156, 0.6)',
-    color: '#fff',
     height: '63px',
     hoverBackgroundColor: '#f5f8fa',
     offsetHeight: '64px',

--- a/packages/synapse-guest-module/setup.cfg
+++ b/packages/synapse-guest-module/setup.cfg
@@ -29,7 +29,7 @@ dev =
   twisted
   aiounittest
   # for type checking
-  mypy == 0.931
+  mypy == 1.10.0
   pydantic == 2.4.2
   # for linting
   black == 22.3.0


### PR DESCRIPTION
<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

This allows setting a specific color other than white for the launcher icon when the navigation menu is expanded, thus enabling other colors when having a lower contrast action accent color configured.

**Before**
<img width="314" alt="before" src="https://github.com/nordeck/element-web-modules/assets/26399/fc61272b-8399-4775-91d9-7a415b2a7bf0">

**After**
<img width="313" alt="after" src="https://github.com/nordeck/element-web-modules/assets/26399/b9049af3-bf31-483d-a261-bc5ec1754fa9">

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [X] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [X] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [X] Screenshots or videos attached (for UI changes).
- [X] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
