### PR TITLE
fix builds without guest module

### DIFF
--- a/.github/workflows/element-with-modules.yml
+++ b/.github/workflows/element-with-modules.yml
@@ -332,7 +332,7 @@ jobs:
       - name: Collect module source files
         run: |
           mv ../build_config.yaml e2e/src/deploy/elementWeb/
-          mv ../customisations.json e2e/src/deploy/elementWeb/ || ${{ matrix.guest == 'none' }}
+          if ${{ matrix.guest == 'none' }}; then rm e2e/src/deploy/elementWeb/customisations.json; else mv ../customisations.json e2e/src/deploy/elementWeb/; fi
           mv ../nordeck-element-web-guest-module.tgz e2e/src/deploy/elementWeb/ || ${{ startsWith(matrix.guest, '@nordeck') || startsWith(matrix.guest, 'none') }}
           mv ../nordeck-element-web-opendesk-module.tgz e2e/src/deploy/elementWeb/ || ${{ startsWith(matrix.opendesk, '@nordeck') || startsWith(matrix.opendesk, 'none') }}
           mv ../nordeck-element-web-widget-lifecycle-module.tgz e2e/src/deploy/elementWeb/ || ${{ startsWith(matrix.lifecycle, '@nordeck') || startsWith(matrix.lifecycle, 'none') }}

--- a/e2e/src/deploy/elementWeb/Dockerfile
+++ b/e2e/src/deploy/elementWeb/Dockerfile
@@ -16,7 +16,8 @@ RUN yarn --network-timeout=200000 install
 # Add all configurations
 COPY /*.tgz /src/
 COPY /build_config.yaml /src
-COPY /customisations.json /src
+# COPY if exists (https://stackoverflow.com/a/70096420)
+COPY /customisations.jso[n] /src
 
 # Build Element
 RUN bash /src/scripts/docker-package.sh


### PR DESCRIPTION
The guest module requires the customisations.json with certain settings. The previous condition did not properly remove the file when the guest module was not included in the build: https://github.com/nordeck/element-web-modules/actions/runs/12711712130/job/35435639988#step:25:1215
This updated condition actively removes the file and updates the Dockerfile to not fail when it does not exist: https://github.com/nordeck/element-web-modules/actions/runs/12712355476

<!-- Thank you for creating a Pull Request!
     Please take a moment to provide some more details: -->

<!-- Please describe what you added, and add a screenshot or video if possible.
     That makes it easier to understand the change. -->

**:heavy_check_mark: Checklist**

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] A changeset describing the change and affected packages ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#changelog-and-versioning)).
- [ ] Added or updated documentation.
- [ ] Tests for new functionality and regression tests for bug fixes.
- [ ] Screenshots or videos attached (for UI changes).
- [x] All your commits have a `Signed-off-by` line in the message ([more info](https://github.com/nordeck/.github/blob/main/docs/CONTRIBUTING.md#dco)).
